### PR TITLE
Use Assignment Expression (Walrus) In Conditional

### DIFF
--- a/event-handler/event_handler.py
+++ b/event-handler/event_handler.py
@@ -80,8 +80,7 @@ def publish_to_pubsub(source, msg, headers):
             topic_path, data=msg, headers=json.dumps(headers)
         )
 
-        exception = future.exception()
-        if exception:
+        if exception := future.exception():
             raise Exception(exception)
 
         print(f"Published message: {future.result()}")

--- a/terraform/modules/fourkeys-images/files/event-handler/event_handler.py
+++ b/terraform/modules/fourkeys-images/files/event-handler/event_handler.py
@@ -80,8 +80,7 @@ def publish_to_pubsub(source, msg, headers):
             topic_path, data=msg, headers=json.dumps(headers)
         )
 
-        exception = future.exception()
-        if exception:
+        if exception := future.exception():
             raise Exception(exception)
 
         print(f"Published message: {future.result()}")


### PR DESCRIPTION
This codemod updates places where two separate statements involving an assignment and conditional can be replaced with a single Assignment Expression (commonly known as the walrus operator).

Many developers use this operator in new code that they write but don't have the time to find and update every place in existing code. So we do it for you! We believe this leads to more concise and readable code.

The changes from this codemod look like this:

```diff
- x = foo()
- if x is not None:
+ if (x := foo()) is not None:
      print(x)
```

The walrus operator is only supported in Python 3.8 and later.

<details>
  <summary>More reading</summary>

  * [https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions](https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions)
</details>

Powered by: [pixeebot](https://docs.pixee.ai/) (codemod ID: [pixee:python/use-walrus-if](https://docs.pixee.ai/codemods/python/pixee_python_use-walrus-if)) ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7Ccitizenjosh%2Ffourkeys%7Cd677aa312586ff404ce5f1534e48397538081b27)

<!--{"type":"DRIP","codemod":"pixee:python/use-walrus-if"}-->